### PR TITLE
splitting coupling of custom loss and instance weights

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1580,10 +1580,14 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss_fct = self.custom_loss if hasattr(self, 'custom_loss') and self.custom_loss is not None else CrossEntropyLoss(ignore_index=-100)
-            if instance_weights is not None:
-                loss = loss_fct(lm_logits.view(-1, lm_logits.size(-1)), labels.view(-1), instance_weights)
+            if hasattr(self, 'custom_loss') and self.custom_loss is not None:
+                loss_fct = self.custom_loss
+                if instance_weights is not None:
+                    loss = loss_fct(lm_logits.view(-1, lm_logits.size(-1)), labels.view(-1), instance_weights)
+                else:
+                    loss = loss_fct(lm_logits.view(-1, lm_logits.size(-1)), labels.view(-1))
             else:
+                loss_fct = CrossEntropyLoss(ignore_index=-100)
                 loss = loss_fct(lm_logits.view(-1, lm_logits.size(-1)), labels.view(-1))
             # TODO(thom): Add z_loss https://github.com/tensorflow/mesh/blob/fa19d69eafc9a482aff0b59ddd96b025c0cb207d/mesh_tensorflow/layers.py#L666
 


### PR DESCRIPTION
to handle cases where instance weights might be present in the dataset but the default t5 cross entropy loss doesn't accept them